### PR TITLE
user.roles after v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Roles also attach helpers to the ```Meteor.users``` collection.
 
 ```js
 var user = Meteor.user();
-var roles = user.roles();
+var roles = user.roles;
 ```
 
 #### Check if a user has a role


### PR DESCRIPTION
user.roles is not a function(…) error, when Meteor.user().roles() used after migration to v2.0.

Use Meteor.user().roles instead.
